### PR TITLE
incorrect cisuseraccount ids fixed

### DIFF
--- a/custom/rules/cisuseraccounts/cisuseraccounts_disable_autorun_files_safari.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_disable_autorun_files_safari.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_disable_autorun_files_safari
+id: cisuseraccounts_disable_autorun_files_safari
 title: "Disable the automatic run of safe files in Safari (Automated)"
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_enable_filename_extensions.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_enable_filename_extensions.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_enable_filename_extensions
+id: cisuseraccounts_enable_filename_extensions
 title: "Turn on filename extensions (Automated)"
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_guest_access_smb_disable.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_guest_access_smb_disable.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_guest_access_smb_disable
+id: cisuseraccounts_guest_access_smb_disable
 title: 'Disable "Allow guests to connect to shared folders" (Automated)'
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_guest_account_disable.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_guest_account_disable.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_guest_account_disable
+id: cisuseraccounts_guest_account_disable
 title: "Disable guest account login (Automated)"
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_loginwindow_prompt_username_password_enforce.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_loginwindow_prompt_username_password_enforce.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_loginwindow_prompt_username_password_enforce
+id: cisuseraccounts_loginwindow_prompt_username_password_enforce
 title: "Display login window as name and password (Automated)"
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_password_hints_disable.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_password_hints_disable.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_password_hints_disable
+id: cisuseraccounts_password_hints_disable
 title: 'Disable "Show password hints" (Automated)'
 discussion: |
   [discrete]

--- a/custom/rules/cisuseraccounts/cisuseraccounts_remove_guest_homefolder.yaml
+++ b/custom/rules/cisuseraccounts/cisuseraccounts_remove_guest_homefolder.yaml
@@ -1,4 +1,4 @@
-id: useraccounts_remove_guest_homefolder
+id: cisuseraccounts_remove_guest_homefolder
 title: "Remove Guest home folder (Automated)"
 discussion: |
   [discrete]


### PR DESCRIPTION
Issue described in the following link is now fixed: https://github.com/mvdbent/CIS-macOS-Security/issues/1#issue-999646272